### PR TITLE
Add warning for deprecated Robocorp code extension

### DIFF
--- a/sema4ai/vscode-client/src/extension.ts
+++ b/sema4ai/vscode-client/src/extension.ts
@@ -607,10 +607,31 @@ export let globalCachedPythonInfo: InterpreterInfo;
 const langServerMutex: Mutex = new Mutex();
 export let GLOBAL_STATE: undefined | vscode.Memento = undefined;
 
+function checkDeprecatedRobocorpCoreExtension() {
+    const robocorpExtensionId = "Robocorp.robocorp-code";
+    const robocorpExtension = vscode.extensions.getExtension(robocorpExtensionId);
+    if (robocorpExtension) {
+        OUTPUT_CHANNEL.appendLine(`Found deprecated ${robocorpExtension.packageJSON.displayName} extension.`);
+        vscode.window
+            .showWarningMessage(
+                `The deprecated "${robocorpExtension.packageJSON.displayName}" extension found. It may cause conflicts with the rebranded Sema4ai extension.`,
+                "Open Extensions"
+            )
+            .then((selection) => {
+                if (selection === "Open Extensions") {
+                    vscode.commands.executeCommand("workbench.view.extensions");
+                }
+            });
+    }
+}
+
 export async function activate(context: ExtensionContext) {
     GLOBAL_STATE = context.globalState;
     let timing = new Timing();
     OUTPUT_CHANNEL.appendLine("Activating Sema4.ai extension.");
+
+    checkDeprecatedRobocorpCoreExtension();
+
     registerLinkProviders(context);
 
     C = new CommandRegistry(context);


### PR DESCRIPTION
Unfortunately the is no API to disable or uninstall an extension, otherwise I would have added a button to do so.

Was considering to add instructions how to install, but the information message doesn't support any new lines, so instead opted to just have a button that open the extensions. Any vscode user should manage from there.