### PR TITLE
Duplicate ROBOCORP_HOME as SEMA4AI_HOME

### DIFF
--- a/sema4ai/codegen/settings.py
+++ b/sema4ai/codegen/settings.py
@@ -71,7 +71,7 @@ SETTINGS = [
     Setting(
         "sema4ai.home",
         "",
-        "Specifies the value for ROBOCORP_HOME (where the conda environments will be downloaded). Must point to a directory without spaces in it.",
+        "Specifies the value for SEMA4AI_HOME (where the conda environments will be downloaded). Must point to a directory without spaces in it.",
         setting_type="string",
     ),
     Setting(

--- a/sema4ai/package.json
+++ b/sema4ai/package.json
@@ -174,7 +174,7 @@
                 "sema4ai.home": {
                     "type": "string",
                     "default": "",
-                    "description": "Specifies the value for ROBOCORP_HOME (where the conda environments will be downloaded). Must point to a directory without spaces in it."
+                    "description": "Specifies the value for SEMA4AI_HOME (where the conda environments will be downloaded). Must point to a directory without spaces in it."
                 },
                 "sema4ai.verifyLSP": {
                     "type": "boolean",

--- a/sema4ai/src/sema4ai_code/holetree_manager.py
+++ b/sema4ai/src/sema4ai_code/holetree_manager.py
@@ -75,7 +75,7 @@ class HolotreeManager:
             info.
 
             Usually it should not be passed and it defaults to something
-            as ROBOCORP_HOME/.vscode (but a different path can be used for
+            as SEMA4AI_HOME/.vscode (but a different path can be used for
             tests).
         """
         self._rcc = rcc

--- a/sema4ai/src/sema4ai_code/rcc.py
+++ b/sema4ai/src/sema4ai_code/rcc.py
@@ -308,6 +308,7 @@ class Rcc(object):
         robocorp_home = self.get_robocorp_home_from_settings()
         if robocorp_home:
             env["ROBOCORP_HOME"] = robocorp_home
+            env["SEMA4AI_HOME"] = robocorp_home
 
         kwargs: dict = build_subprocess_kwargs(cwd, env, stderr=stderr)
         args = [rcc_location] + args + ["--controller", "Sema4aiCode"]

--- a/sema4ai/vscode-client/src/debugger.ts
+++ b/sema4ai/vscode-client/src/debugger.ts
@@ -219,8 +219,10 @@ export function registerDebugger() {
         if (robotHome && robotHome.length > 0) {
             if (env) {
                 env["ROBOCORP_HOME"] = robotHome;
+                env["SEMA4AI_HOME"] = robotHome
             } else {
                 env = { "ROBOCORP_HOME": robotHome };
+                env = { "SEMA4AI_HOME": robotHome }
             }
         }
         let targetMain: string = path.resolve(__dirname, "../../src/sema4ai_code_debug_adapter/__main__.py");

--- a/sema4ai/vscode-client/src/debugger.ts
+++ b/sema4ai/vscode-client/src/debugger.ts
@@ -219,10 +219,10 @@ export function registerDebugger() {
         if (robotHome && robotHome.length > 0) {
             if (env) {
                 env["ROBOCORP_HOME"] = robotHome;
-                env["SEMA4AI_HOME"] = robotHome
+                env["SEMA4AI_HOME"] = robotHome;
             } else {
                 env = { "ROBOCORP_HOME": robotHome };
-                env = { "SEMA4AI_HOME": robotHome }
+                env = { "SEMA4AI_HOME": robotHome };
             }
         }
         let targetMain: string = path.resolve(__dirname, "../../src/sema4ai_code_debug_adapter/__main__.py");

--- a/sema4ai/vscode-client/src/extensionCreateEnv.ts
+++ b/sema4ai/vscode-client/src/extensionCreateEnv.ts
@@ -313,15 +313,15 @@ export async function basicValidations(
         return { success: false, message: "", result: rccDiagnostics };
     }
     while (!rccDiagnostics.isRobocorpHomeOk()) {
-        const SELECT_ROBOCORP_HOME = "Set new ROBOCORP_HOME";
+        const SELECT_ROBOCORP_HOME = "Set new SEMA4AI_HOME";
         const CANCEL = "Cancel";
         let result = await window.showInformationMessage(
-            "The current ROBOCORP_HOME is invalid (paths with spaces/non ascii chars are not supported).",
+            "The current SEMA4AI_HOME is invalid (paths with spaces/non ascii chars are not supported).",
             SELECT_ROBOCORP_HOME,
             CANCEL
         );
         if (!result || result == CANCEL) {
-            OUTPUT_CHANNEL.appendLine("Cancelled setting new ROBOCORP_HOME.");
+            OUTPUT_CHANNEL.appendLine("Cancelled setting new SEMA4AI_HOME.");
             feedbackRobocorpCodeError("INIT_INVALID_ROBOCORP_HOME");
             if (failsPreventStartup) {
                 return { success: false, message: "", result: rccDiagnostics };
@@ -334,10 +334,10 @@ export async function basicValidations(
             "canSelectFolders": true,
             "canSelectFiles": false,
             "canSelectMany": false,
-            "openLabel": "Set as ROBOCORP_HOME",
+            "openLabel": "Set as SEMA4AI_HOME",
         });
         if (!uriResult) {
-            OUTPUT_CHANNEL.appendLine("Cancelled getting ROBOCORP_HOME path.");
+            OUTPUT_CHANNEL.appendLine("Cancelled getting SEMA4AI_HOME path.");
             feedbackRobocorpCodeError("INIT_CANCELLED_ROBOCORP_HOME");
             if (failsPreventStartup) {
                 return { success: false, message: "", result: rccDiagnostics };
@@ -346,7 +346,7 @@ export async function basicValidations(
             }
         }
         if (uriResult.length != 1) {
-            OUTPUT_CHANNEL.appendLine("Expected 1 path to set as ROBOCORP_HOME. Found: " + uriResult.length);
+            OUTPUT_CHANNEL.appendLine("Expected 1 path to set as SEMA4AI_HOME. Found: " + uriResult.length);
             feedbackRobocorpCodeError("INIT_ROBOCORP_HOME_NO_PATH");
             if (failsPreventStartup) {
                 return { success: false, message: "", result: rccDiagnostics };
@@ -371,7 +371,7 @@ export async function basicValidations(
             }
         }
         if (rccDiagnostics.isRobocorpHomeOk()) {
-            OUTPUT_CHANNEL.appendLine("Selected ROBOCORP_HOME: " + robocorpHome);
+            OUTPUT_CHANNEL.appendLine("Selected SEMA4AI_HOME: " + robocorpHome);
             let config = workspace.getConfiguration("sema4ai");
             await config.update("home", robocorpHome, ConfigurationTarget.Global);
         }
@@ -717,6 +717,7 @@ function extractInfoFromJsonContents(initialJsonContents: string): ActionResult<
         OUTPUT_CHANNEL.appendLine("    ROBOT_ARTIFACTS: " + env["ROBOT_ARTIFACTS"]);
         OUTPUT_CHANNEL.appendLine("    RCC_INSTALLATION_ID: " + env["RCC_INSTALLATION_ID"]);
         OUTPUT_CHANNEL.appendLine("    ROBOCORP_HOME: " + env["ROBOCORP_HOME"]);
+        OUTPUT_CHANNEL.appendLine("    SEMA4AI_HOME: " + env["SEMA4AI_HOME"]);
         OUTPUT_CHANNEL.appendLine("    PROCESSOR_ARCHITECTURE: " + env["PROCESSOR_ARCHITECTURE"]);
         OUTPUT_CHANNEL.appendLine("    OS: " + env["OS"]);
         OUTPUT_CHANNEL.appendLine("    PATH: " + env["PATH"]);

--- a/sema4ai/vscode-client/src/rcc.ts
+++ b/sema4ai/vscode-client/src/rcc.ts
@@ -23,7 +23,17 @@ export enum Metrics {
 
 export async function getRobocorpHome(): Promise<string> {
     let robocorpHome: string = roboConfig.getHome();
+
     if (!robocorpHome || robocorpHome.length == 0) {
+        const sema4aiHome =  process.env["SEMA4AI_HOME"]
+        if (sema4aiHome) {
+            if (lastPrintedRobocorpHome != sema4aiHome) {
+                lastPrintedRobocorpHome = sema4aiHome;
+                OUTPUT_CHANNEL.appendLine("SEMA4AI_HOME: " + sema4aiHome);
+            }
+            return sema4aiHome;
+        }
+
         robocorpHome = process.env["ROBOCORP_HOME"];
         if (!robocorpHome) {
             // Default from RCC (maybe it should provide an API to get it before creating an env?)
@@ -42,7 +52,7 @@ export async function getRobocorpHome(): Promise<string> {
 }
 
 export function createEnvWithRobocorpHome(robocorpHome: string): { [key: string]: string | null } {
-    const base = { "ROBOCORP_HOME": robocorpHome };
+    const base = { "ROBOCORP_HOME": robocorpHome, "SEMA4AI_HOME": robocorpHome };
     if (getProceedwithlongpathsdisabled()) {
         base["ROBOCORP_OVERRIDE_SYSTEM_REQUIREMENTS"] = "1";
     }
@@ -387,7 +397,7 @@ export async function runConfigDiagnostics(
     let configureLongpathsOutput: ExecFileReturn | undefined = undefined;
     let timing = new Timing();
     try {
-        let env = mergeEnviron({ "ROBOCORP_HOME": robocorpHome });
+        let env = mergeEnviron({ "ROBOCORP_HOME": robocorpHome, "SEMA4AI_HOME": robocorpHome});
         configureLongpathsOutput = await execFilePromise(
             rccLocation,
             ["configure", "diagnostics", "-j", "--controller", "Sema4aiCode"],

--- a/sema4ai/vscode-client/src/rcc.ts
+++ b/sema4ai/vscode-client/src/rcc.ts
@@ -25,7 +25,7 @@ export async function getRobocorpHome(): Promise<string> {
     let robocorpHome: string = roboConfig.getHome();
 
     if (!robocorpHome || robocorpHome.length == 0) {
-        const sema4aiHome =  process.env["SEMA4AI_HOME"]
+        const sema4aiHome = process.env["SEMA4AI_HOME"];
         if (sema4aiHome) {
             if (lastPrintedRobocorpHome != sema4aiHome) {
                 lastPrintedRobocorpHome = sema4aiHome;
@@ -397,7 +397,7 @@ export async function runConfigDiagnostics(
     let configureLongpathsOutput: ExecFileReturn | undefined = undefined;
     let timing = new Timing();
     try {
-        let env = mergeEnviron({ "ROBOCORP_HOME": robocorpHome, "SEMA4AI_HOME": robocorpHome});
+        let env = mergeEnviron({ "ROBOCORP_HOME": robocorpHome, "SEMA4AI_HOME": robocorpHome });
         configureLongpathsOutput = await execFilePromise(
             rccLocation,
             ["configure", "diagnostics", "-j", "--controller", "Sema4aiCode"],


### PR DESCRIPTION
Tested with setting first env variable SEMA4AI_HOME to new path and then running a task. RCC ended up using the correct location pointed in env variable SEMA4AI_HOME.

Also tested the same thing with env variable ROBOCORP_HOME and got the same results.

This does duplicate the env variable for now, but it's probably easiest way to make sure that at least RCC is using the correct path always.