### PR TITLE
Add UI element to build action package to WS

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ Unreleased
 - Hide command to authenticate the Action Server to Control Room
 - Hide command for publishing Action Package to Control Room
 - Add command to build Action Package to current workspace
+- Add UI element under activities to build Action Package to current workspace
 
 New in 1.22.4 (2024-05-22)
 -----------------------------

--- a/sema4ai/vscode-client/src/robo/actionPackage.ts
+++ b/sema4ai/vscode-client/src/robo/actionPackage.ts
@@ -517,7 +517,9 @@ const waitUntilPackageVerified = async (
             progress.report({ message: `Status - ${status}` });
 
             if (status === "failed") {
-                window.showErrorMessage(`Action package failed to be uploaded: ${packageStatus.error || "unknown error"}`);
+                window.showErrorMessage(
+                    `Action package failed to be uploaded: ${packageStatus.error || "unknown error"}`
+                );
                 if (timeout) {
                     clearTimeout(timeout);
                 }
@@ -660,7 +662,7 @@ export const publishActionPackage = async () => {
     );
 };
 
-export const buildActionPackage = async() => {
+export const buildActionPackage = async () => {
     const workspaceDir = await askForWs();
 
     await window.withProgress(
@@ -680,7 +682,11 @@ export const buildActionPackage = async() => {
             }
 
             progress.report({ message: "Building package" });
-            const packagePath = await buildPackage(actionServerLocation, workspaceDir.uri.fsPath, workspaceDir.uri.fsPath);
+            const packagePath = await buildPackage(
+                actionServerLocation,
+                workspaceDir.uri.fsPath,
+                workspaceDir.uri.fsPath
+            );
             if (!packagePath) {
                 return;
             }

--- a/sema4ai/vscode-client/src/viewsCommon.ts
+++ b/sema4ai/vscode-client/src/viewsCommon.ts
@@ -37,6 +37,7 @@ export enum RobotEntryType {
     StartActionServer,
     PackageRebuildEnvironment,
     PackagePublishToDesktopApp,
+    PackageBuildToWorkspace,
 }
 
 export interface CloudEntry {

--- a/sema4ai/vscode-client/src/viewsRobots.ts
+++ b/sema4ai/vscode-client/src/viewsRobots.ts
@@ -282,7 +282,7 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
                         "iconPath": "archive",
                         "type": RobotEntryType.PackageBuildToWorkspace,
                         "parent": element,
-                        "tooltip": "Build the Action Package .zip file to the workspace folder",
+                        "tooltip": "Create the Action Package .zip file to the workspace folder",
                     },
                 ];
             } else if (element.type === RobotEntryType.Robot) {
@@ -508,7 +508,7 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
             treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
         } else if (element.type === RobotEntryType.PackageBuildToWorkspace) {
             treeItem.command = {
-                "title": "Build Package to Workspace",
+                "title": "Create Action Package to Workspace",
                 "command": roboCommands.SEMA4AI_ACTION_SERVER_PACKAGE_BUILD,
             };
             treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;

--- a/sema4ai/vscode-client/src/viewsRobots.ts
+++ b/sema4ai/vscode-client/src/viewsRobots.ts
@@ -506,8 +506,7 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
                 "command": roboCommands.SEMA4AI_PACKAGE_PUBLISH_TO_DESKTOP_APP,
             };
             treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
-        }
-        else if (element.type === RobotEntryType.PackageBuildToWorkspace) {
+        } else if (element.type === RobotEntryType.PackageBuildToWorkspace) {
             treeItem.command = {
                 "title": "Build Package to Workspace",
                 "command": roboCommands.SEMA4AI_ACTION_SERVER_PACKAGE_BUILD,

--- a/sema4ai/vscode-client/src/viewsRobots.ts
+++ b/sema4ai/vscode-client/src/viewsRobots.ts
@@ -276,7 +276,7 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
                         "tooltip": "Publishes the Action Package to the Sema4.ai Desktop application",
                     },
                     {
-                        "label": "Build Package to Workspace",
+                        "label": "Create Action Package",
                         "uri": element.uri,
                         "robot": element.robot,
                         "iconPath": "archive",

--- a/sema4ai/vscode-client/src/viewsRobots.ts
+++ b/sema4ai/vscode-client/src/viewsRobots.ts
@@ -275,6 +275,15 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
                         "parent": element,
                         "tooltip": "Publishes the Action Package to the Sema4.ai Desktop application",
                     },
+                    {
+                        "label": "Build Package to Workspace",
+                        "uri": element.uri,
+                        "robot": element.robot,
+                        "iconPath": "archive",
+                        "type": RobotEntryType.PackageBuildToWorkspace,
+                        "parent": element,
+                        "tooltip": "Build the Action Package .zip file to the workspace folder",
+                    },
                 ];
             } else if (element.type === RobotEntryType.Robot) {
                 let yamlContents = element.robot.yamlContents;
@@ -495,6 +504,13 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
             treeItem.command = {
                 "title": "Publish Package to Sema4.ai Desktop",
                 "command": roboCommands.SEMA4AI_PACKAGE_PUBLISH_TO_DESKTOP_APP,
+            };
+            treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
+        }
+        else if (element.type === RobotEntryType.PackageBuildToWorkspace) {
+            treeItem.command = {
+                "title": "Build Package to Workspace",
+                "command": roboCommands.SEMA4AI_ACTION_SERVER_PACKAGE_BUILD,
             };
             treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
         }


### PR DESCRIPTION
Added a UI element under the activities to build Action package to the workspace.

I wanted to use the "build" icons from https://github.com/microsoft/vscode-icons?tab=readme-ov-file, but that doesn't seem to be available. The icon was empty if "build" was used. Ended up using the "archive" icon instead.