### PR TITLE
Add command and UI to create AP metadata.json

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 Unreleased
 -----------------------------
 
+- Add command and UI element to create metadata file for Action Package
 
 New in 2.1.0 (2024-06-25)
 

--- a/sema4ai/codegen/commands.py
+++ b/sema4ai/codegen/commands.py
@@ -862,6 +862,18 @@ COMMANDS = [
         server_handled=False,
         hide_from_command_palette=True,
     ),
+    Command(
+        "sema4ai.actionServerPackageMetadata",
+        "Create Action Package metadata file",
+        server_handled=False,
+        hide_from_command_palette=False,
+    ),
+    Command(
+        "sema4ai.actionServerPackageMetadata.internal",
+        "Create Action Package metadata file (internal)",
+        server_handled=True,
+        hide_from_command_palette=True,
+    ),
 ]
 
 

--- a/sema4ai/package.json
+++ b/sema4ai/package.json
@@ -139,6 +139,8 @@
         "onCommand:sema4ai.actionServerPackageStatus.internal",
         "onCommand:sema4ai.actionServerPackageSetChangelog.internal",
         "onCommand:sema4ai.actionServerPackagePublish",
+        "onCommand:sema4ai.actionServerPackageMetadata",
+        "onCommand:sema4ai.actionServerPackageMetadata.internal",
         "onDebugInitialConfigurations",
         "onDebugResolve:sema4ai",
         "onView:sema4ai-task-packages-tree",
@@ -883,6 +885,16 @@
                 "command": "sema4ai.actionServerPackagePublish",
                 "title": "Publish Action Package to Control Room",
                 "category": "Sema4.ai"
+            },
+            {
+                "command": "sema4ai.actionServerPackageMetadata",
+                "title": "Create Action Package metadata file",
+                "category": "Sema4.ai"
+            },
+            {
+                "command": "sema4ai.actionServerPackageMetadata.internal",
+                "title": "Create Action Package metadata file (internal)",
+                "category": "Sema4.ai"
             }
         ],
         "menus": {
@@ -1393,6 +1405,10 @@
                 },
                 {
                     "command": "sema4ai.actionServerPackagePublish",
+                    "when": "false"
+                },
+                {
+                    "command": "sema4ai.actionServerPackageMetadata.internal",
                     "when": "false"
                 }
             ]

--- a/sema4ai/src/sema4ai_code/commands.py
+++ b/sema4ai/src/sema4ai_code/commands.py
@@ -121,6 +121,8 @@ SEMA4AI_ACTION_SERVER_PACKAGE_UPLOAD_INTERNAL = "sema4ai.actionServerPackageUplo
 SEMA4AI_ACTION_SERVER_PACKAGE_STATUS_INTERNAL = "sema4ai.actionServerPackageStatus.internal"  # Get action package upload status from the Control Room (internal)
 SEMA4AI_ACTION_SERVER_PACKAGE_SET_CHANGELOG_INTERNAL = "sema4ai.actionServerPackageSetChangelog.internal"  # Set action package changelog entry in the Control Room (internal)
 SEMA4AI_ACTION_SERVER_PACKAGE_PUBLISH = "sema4ai.actionServerPackagePublish"  # Publish Action Package to Control Room
+SEMA4AI_ACTION_SERVER_PACKAGE_METADATA = "sema4ai.actionServerPackageMetadata"  # Create Action Package metadata file
+SEMA4AI_ACTION_SERVER_PACKAGE_METADATA_INTERNAL = "sema4ai.actionServerPackageMetadata.internal"  # Create Action Package metadata file (internal)
 
 ALL_SERVER_COMMANDS = [
     SEMA4AI_GET_PLUGINS_DIR,
@@ -166,6 +168,7 @@ ALL_SERVER_COMMANDS = [
     SEMA4AI_ACTION_SERVER_PACKAGE_UPLOAD_INTERNAL,
     SEMA4AI_ACTION_SERVER_PACKAGE_STATUS_INTERNAL,
     SEMA4AI_ACTION_SERVER_PACKAGE_SET_CHANGELOG_INTERNAL,
+    SEMA4AI_ACTION_SERVER_PACKAGE_METADATA_INTERNAL,
 ]
 
 # fmt: on

--- a/sema4ai/src/sema4ai_code/protocols.py
+++ b/sema4ai/src/sema4ai_code/protocols.py
@@ -315,6 +315,12 @@ class ActionServerPackageSetChangelogDict(TypedDict):
     hostname: Optional[str]
 
 
+class ActionServerPackageMetadataDict(TypedDict):
+    action_server_location: str
+    input_dir: str
+    output_dir: str
+
+
 class IRccWorkspace(Protocol):
     @property
     def workspace_id(self) -> str:

--- a/sema4ai/src/sema4ai_code/robocorp_language_server.py
+++ b/sema4ai/src/sema4ai_code/robocorp_language_server.py
@@ -57,6 +57,7 @@ from sema4ai_code.protocols import (
     ActionServerPackageUploadStatusDict,
     ActionServerPackageStatusDict,
     ActionServerPackageSetChangelogDict,
+    ActionServerPackageMetadataDict,
 )
 from sema4ai_code.vendored_deps.package_deps._deps_protocols import (
     ICondaCloud,
@@ -1609,6 +1610,20 @@ class RobocorpLanguageServer(PythonLanguageServer, InspectorLanguageServer):
         return action_server.package_set_changelog(
             package_id, organization_id, changelog_input, access_credentials, hostname
         ).as_dict()
+
+    @command_dispatcher(commands.SEMA4AI_ACTION_SERVER_PACKAGE_METADATA_INTERNAL)
+    def _action_server_package_metadata(
+        self, params: ActionServerPackageMetadataDict
+    ) -> ActionResultDict:
+        from sema4ai_code.action_server import ActionServer
+
+        action_server_location = params["action_server_location"]
+        input_dir = params["input_dir"]
+        output_dir = params["output_dir"]
+
+        action_server = ActionServer(action_server_location)
+
+        return action_server.package_metadata(input_dir, output_dir).as_dict()
 
     def forward_msg(self, msg: dict) -> None:
         method = msg["method"]

--- a/sema4ai/tests/sema4ai_code_tests/test_vscode_integration/test_package_metadata.yml
+++ b/sema4ai/tests/sema4ai_code_tests/test_vscode_integration/test_package_metadata.yml
@@ -1,0 +1,74 @@
+metadata:
+  description: used for testing only
+  name: test_action
+  secrets: {}
+  version: 1
+openapi.json:
+  components:
+    schemas:
+      HTTPValidationError:
+        properties:
+          errors:
+            items:
+              $ref: '#/components/schemas/ValidationError'
+            title: Errors
+            type: array
+        title: HTTPValidationError
+        type: object
+      ValidationError:
+        properties:
+          loc:
+            items:
+              anyOf:
+              - type: string
+              - type: integer
+            title: Location
+            type: array
+          msg:
+            title: Message
+            type: string
+          type:
+            title: Error Type
+            type: string
+        required:
+        - loc
+        - msg
+        - type
+        title: ValidationError
+        type: object
+  paths:
+    /api/actions/test-action/my-action/run:
+      post:
+        description: My docstring
+        operationId: my_action
+        requestBody:
+          content:
+            application/json:
+              schema:
+                properties:
+                  arg1:
+                    description: this is argument...
+                    title: Arg1
+                    type: string
+                required:
+                - arg1
+                type: object
+          required: true
+        responses:
+          '200':
+            content:
+              application/json:
+                schema:
+                  description: ''
+                  title: Response for My Action
+                  type: string
+            description: Successful Response
+          '422':
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/HTTPValidationError'
+            description: Validation Error
+        summary: My Action
+  servers:
+  - url: http://localhost:8080

--- a/sema4ai/vscode-client/src/actionServer.ts
+++ b/sema4ai/vscode-client/src/actionServer.ts
@@ -277,19 +277,23 @@ const startActionServerInternal = async (directory: Uri) => {
     actionServerTerminal.sendText(`${location} start --port=${ACTION_SERVER_DEFAULT_PORT}`);
 };
 
+export const findActionPackagePath = async (): Promise<Uri | undefined> => {
+    // Need to list the action packages available to decide
+    // which one to use for the action server.
+    const selected = await listAndAskRobotSelection(
+        "Please select the Action Package from which the Action Server should load actions.",
+        "Unable to start Action Server because no Action Package was found in the workspace.",
+        { showActionPackages: true, showTaskPackages: false }
+    );
+    if (!selected) {
+        return;
+    }
+    return Uri.file(selected.directory);
+};
+
 export const startActionServer = async (directory: Uri) => {
     if (!directory) {
-        // Need to list the action packages available to decide
-        // which one to use for the action server.
-        const selected = await listAndAskRobotSelection(
-            "Please select the Action Package from which the Action Server should load actions.",
-            "Unable to start Action Server because no Action Package was found in the workspace.",
-            { showActionPackages: true, showTaskPackages: false }
-        );
-        if (!selected) {
-            return;
-        }
-        directory = Uri.file(selected.directory);
+        directory = await findActionPackagePath();
     }
 
     let actionServerTerminal: Terminal = getActionServerTerminal();

--- a/sema4ai/vscode-client/src/extension.ts
+++ b/sema4ai/vscode-client/src/extension.ts
@@ -24,17 +24,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import * as cp from "child_process";
 
-import {
-    workspace,
-    Disposable,
-    ExtensionContext,
-    window,
-    commands,
-    extensions,
-    env,
-    Uri,
-    WorkspaceFolder,
-} from "vscode";
+import { workspace, Disposable, ExtensionContext, window, commands, extensions, env, Uri } from "vscode";
 import { LanguageClientOptions, State } from "vscode-languageclient";
 import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
 import * as playwright from "./playwright";
@@ -157,6 +147,7 @@ import {
     SEMA4AI_ACTION_SERVER_CLOUD_LOGIN,
     SEMA4AI_ACTION_SERVER_PACKAGE_PUBLISH,
     SEMA4AI_ACTION_SERVER_PACKAGE_BUILD,
+    SEMA4AI_ACTION_SERVER_PACKAGE_METADATA,
 } from "./robocorpCommands";
 import { installWorkspaceWatcher } from "./pythonExtIntegration";
 import { refreshCloudTreeView } from "./viewsRobocorp";
@@ -181,6 +172,7 @@ import {
     createActionPackage,
     publishActionPackage,
     buildActionPackage,
+    createMetadata,
 } from "./robo/actionPackage";
 import { showSelectOneStrQuickPick } from "./ask";
 import { getSema4DesktopURLForFolderPath } from "./deepLink";
@@ -491,6 +483,7 @@ function registerRobocorpCodeCommands(C: CommandRegistry, context: ExtensionCont
     C.register(SEMA4AI_ACTION_SERVER_CLOUD_LOGIN, async () => await actionServerCloudLogin());
     C.register(SEMA4AI_ACTION_SERVER_PACKAGE_PUBLISH, async () => await publishActionPackage());
     C.register(SEMA4AI_ACTION_SERVER_PACKAGE_BUILD, async () => await buildActionPackage());
+    C.register(SEMA4AI_ACTION_SERVER_PACKAGE_METADATA, createMetadata);
 }
 
 async function clearEnvAndRestart() {

--- a/sema4ai/vscode-client/src/robocorpCommands.ts
+++ b/sema4ai/vscode-client/src/robocorpCommands.ts
@@ -120,3 +120,5 @@ export const SEMA4AI_ACTION_SERVER_PACKAGE_UPLOAD_INTERNAL = "sema4ai.actionServ
 export const SEMA4AI_ACTION_SERVER_PACKAGE_STATUS_INTERNAL = "sema4ai.actionServerPackageStatus.internal";  // Get action package upload status from the Control Room (internal)
 export const SEMA4AI_ACTION_SERVER_PACKAGE_SET_CHANGELOG_INTERNAL = "sema4ai.actionServerPackageSetChangelog.internal";  // Set action package changelog entry in the Control Room (internal)
 export const SEMA4AI_ACTION_SERVER_PACKAGE_PUBLISH = "sema4ai.actionServerPackagePublish";  // Publish Action Package to Control Room
+export const SEMA4AI_ACTION_SERVER_PACKAGE_METADATA = "sema4ai.actionServerPackageMetadata";  // Create Action Package metadata file
+export const SEMA4AI_ACTION_SERVER_PACKAGE_METADATA_INTERNAL = "sema4ai.actionServerPackageMetadata.internal";  // Create Action Package metadata file (internal)

--- a/sema4ai/vscode-client/src/viewsCommon.ts
+++ b/sema4ai/vscode-client/src/viewsCommon.ts
@@ -38,6 +38,7 @@ export enum RobotEntryType {
     PackageRebuildEnvironment,
     PackagePublishToDesktopApp,
     PackageBuildToWorkspace,
+    PackageMetadataToWorkspace,
 }
 
 export interface CloudEntry {

--- a/sema4ai/vscode-client/src/viewsRobots.ts
+++ b/sema4ai/vscode-client/src/viewsRobots.ts
@@ -291,7 +291,7 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
                         "iconPath": "json",
                         "type": RobotEntryType.PackageMetadataToWorkspace,
                         "parent": element,
-                        "tooltip": "Create metadata.json file to the Action Package folder",
+                        "tooltip": "Create metadata.json file in Action Package folder",
                     },
                 ];
             } else if (element.type === RobotEntryType.Robot) {

--- a/sema4ai/vscode-client/src/viewsRobots.ts
+++ b/sema4ai/vscode-client/src/viewsRobots.ts
@@ -284,6 +284,15 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
                         "parent": element,
                         "tooltip": "Create the Action Package .zip file to the workspace folder",
                     },
+                    {
+                        "label": "Create Metadata File",
+                        "uri": element.uri,
+                        "robot": element.robot,
+                        "iconPath": "json",
+                        "type": RobotEntryType.PackageMetadataToWorkspace,
+                        "parent": element,
+                        "tooltip": "Create metadata.json file to the Action Package folder",
+                    },
                 ];
             } else if (element.type === RobotEntryType.Robot) {
                 let yamlContents = element.robot.yamlContents;
@@ -510,6 +519,13 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
             treeItem.command = {
                 "title": "Create Action Package to Workspace",
                 "command": roboCommands.SEMA4AI_ACTION_SERVER_PACKAGE_BUILD,
+            };
+            treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
+        } else if (element.type === RobotEntryType.PackageMetadataToWorkspace) {
+            treeItem.command = {
+                "title": "Create Metadata File to Workspace",
+                "command": roboCommands.SEMA4AI_ACTION_SERVER_PACKAGE_METADATA,
+                "arguments": [vscode.Uri.file(element.robot.directory)],
             };
             treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
         }


### PR DESCRIPTION
Add command and UI element to create an Action Package metadata.json file into the workspace folder.

I did some debugging on why the Windows is so slow to call the action server executable and noticed that there were some data not given to subprocess, that we give when callin RCC. I added those, but didn't notice any significant difference.