### PR TITLE
Prompt for metadata file update if action files changed

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Unreleased
 - A prompt allowing to restart the Action Server will appear now when an environment file is modified in an Action package with active Action Server.
 - Add UI element to open the metadata file for Action Package
 - Fix build Action Package command to add selection step to select the Action Package in case there are multiple in workspace
+- Prompt for metadata file update if action files have changed
 
 New in 2.1.0 (2024-06-25)
 

--- a/sema4ai/vscode-client/src/viewsRobots.ts
+++ b/sema4ai/vscode-client/src/viewsRobots.ts
@@ -5,6 +5,7 @@ import { LocalRobotMetadataInfo, ActionResult, IActionInfo } from "./protocols";
 import * as roboCommands from "./robocorpCommands";
 import { basename, getSelectedRobot, RobotEntry, RobotEntryType } from "./viewsCommon";
 import { isActionPackage } from "./common";
+import { METADATA_FILE_NAME } from "./robo/actionPackage";
 
 let _globalSentMetric: boolean = false;
 
@@ -285,22 +286,22 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
                         "tooltip": "Create the Action Package .zip file to the workspace folder",
                     },
                     {
-                        "label": "Create Package OpenAPI Spec (metadata.json)",
+                        "label": `Create Package OpenAPI Spec (${METADATA_FILE_NAME})`,
                         "uri": element.uri,
                         "robot": element.robot,
                         "iconPath": "new-file",
                         "type": RobotEntryType.PackageMetadataToWorkspace,
                         "parent": element,
-                        "tooltip": "Create metadata.json file in Action Package folder",
+                        "tooltip": `Create ${METADATA_FILE_NAME} file in Action Package folder`,
                     },
                     {
-                        "label": "View Package OpenAPI Spec (metadata.json)",
+                        "label": `View Package OpenAPI Spec (${METADATA_FILE_NAME})`,
                         "uri": element.uri,
                         "robot": element.robot,
                         "iconPath": "go-to-file",
                         "type": RobotEntryType.OpenMetadataFileToWorkspace,
                         "parent": element,
-                        "tooltip": "Open the Action Package metadata file (metadata.json)",
+                        "tooltip": `Open the Action Package metadata file (${METADATA_FILE_NAME})`,
                     },
                 ];
             } else if (element.type === RobotEntryType.Robot) {
@@ -532,14 +533,14 @@ export class RobotsTreeDataProvider implements vscode.TreeDataProvider<RobotEntr
             treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
         } else if (element.type === RobotEntryType.PackageMetadataToWorkspace) {
             treeItem.command = {
-                "title": "Create Package OpenAPI Spec File to Workspace (metadata.json)",
+                "title": `Create Package OpenAPI Spec File to Workspace (${METADATA_FILE_NAME})`,
                 "command": roboCommands.SEMA4AI_ACTION_SERVER_PACKAGE_METADATA,
                 "arguments": [vscode.Uri.file(element.robot.directory)],
             };
             treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
         } else if (element.type === RobotEntryType.OpenMetadataFileToWorkspace) {
             treeItem.command = {
-                "title": "Open Package OpenAPI Spec File to Workspace (metadata.json)",
+                "title": `Open Package OpenAPI Spec File to Workspace (${METADATA_FILE_NAME})`,
                 "command": roboCommands.SEMA4AI_OPEN_ACTION_PACKAGE_METADATA,
                 "arguments": [vscode.Uri.file(element.robot.directory)],
             };


### PR DESCRIPTION
When the python files in workspace are saved. Prompt user to update the metadata file if it exsists. User can either update it or remove it.

It looks like if multiple files in the same action package are changed only one notification is generated (same content). This is what we want, just wondering what is doing the filtering.

If files are changed in different action packages then notification is generated for each action package (metadata.json file). This is also what we want.