### PR TITLE
Add refresh agent spec internal command to update the action packages…

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,12 +1,20 @@
 ## Unreleased
 
-- New Command: `Open Agent Runbook`.
+- New command: `Sema4.ai: Import Agent Package (Zip)`.
+- New Command: `Sema4.ai: Open Agent Runbook`.
+- When an action package is created inside an agent, the agent spec is updated accordingly.
 - Renamed Commands:
   - Open Agent Spec (agent-spec.yaml) → Configure Agent
   - Configure Action Package (package.yaml) → Configure Action Package
 - UI Update: Moved `Configure Agent` and `Configure Action Package` from the `Commands` section to the top level of the agent/action.
 - Hover for `agent-spec.yaml` (using new spec format for v2)
 - Code analysis for `agent-spec.yaml` (using new spec format for v2)
+  - Basic analysis for the full spec based on paths/types
+  - Checks if the `zip`, `folder` type matches the actual referenced type
+  - Checks if the action package `name` matches the referenced value
+  - Checks if the action package `version` matches the referenced value
+  - Checks that all the actions found under `actions` are properly referenced in the `agent-spec.yaml`
+  - Note: handles both .zip and expanded action packages.
 - New dependency required: `tree-sitter`
 - Update `robocorp-trustore` dependency to 0.9.1
 - No longer use `requests` (due to breakage with truststore)
@@ -22,13 +30,6 @@
 - Accept OAuth2 without `clientSecret` (using `pkce` flow).
 - The yaml for `OAuth2` is now different (saved in new location with new structure).
   - There's now a `mode` which can specify `mode: sema4ai` to use `Sema4.ai` provided configuration (without `clientSecret` required).
-- New command: `Sema4.ai: Import Agent Package (Zip)`.
-- Additional validations in the `agent-spec.yaml` to verify that the information is in sync with linked action packages:
-  - Check if the `zip`, `folder` type matches the actual referenced type
-  - Check if the action package `name` matches the referenced value
-  - Check if the action package `version` matches the referenced value
-  - Checks that all the actions found under `actions` are properly referenced in the `agent-spec.yaml`
-  - Note: handles both .zip and expanded action packages.
 
 ## New in 2.4.2 (2024-08-26)
 

--- a/sema4ai/codegen/commands.py
+++ b/sema4ai/codegen/commands.py
@@ -963,6 +963,12 @@ COMMANDS = [
         server_handled=False,
         hide_from_command_palette=False,
     ),
+    Command(
+        "sema4ai.refreshAgentSpec.internal",
+        "Refresh Agent Spec (internal)",
+        add_to_package_json=False,
+        server_handled=True,
+    ),
 ]
 
 

--- a/sema4ai/package.json
+++ b/sema4ai/package.json
@@ -156,6 +156,7 @@
         "onCommand:sema4ai.getRunbookPathFromAgentSpec.internal",
         "onCommand:sema4ai.agentPackagePublishToSema4AIStudioApp",
         "onCommand:sema4ai.agentPackageImport",
+        "onCommand:sema4ai.refreshAgentSpec.internal",
         "onDebugInitialConfigurations",
         "onDebugResolve:sema4ai",
         "onView:sema4ai-task-packages-tree",

--- a/sema4ai/src/sema4ai_code/action_server.py
+++ b/sema4ai/src/sema4ai_code/action_server.py
@@ -667,7 +667,7 @@ class ActionServer:
             with open(package_path, "w") as file:
                 yaml.dump(package_yaml, file)
 
-            return ActionResult(success=True, message=None)
+            return ActionResult(success=True, message=None, result=package_path)
         else:
             return ActionResult(
                 success=False, message=get_error_message(command_result.message or "")

--- a/sema4ai/src/sema4ai_code/agents/agent_spec_handler.py
+++ b/sema4ai/src/sema4ai_code/agents/agent_spec_handler.py
@@ -637,6 +637,7 @@ class Validator:
                         ):
                             version_in_filesystem = (
                                 package_info_in_filesystem.get_version()
+                                or "Unable to get version from package.yaml"
                             )
                             version_in_agent_package = self._get_value_text(yaml_node)
                             if version_in_filesystem != version_in_agent_package:
@@ -649,7 +650,10 @@ class Validator:
                             spec_node.data.expected_type.expected_type
                             == _ExpectedTypeEnum.action_package_name_link
                         ):
-                            name_in_filesystem = package_info_in_filesystem.get_name()
+                            name_in_filesystem = (
+                                package_info_in_filesystem.get_name()
+                                or "Unable to get name from package.yaml"
+                            )
                             name_in_agent_package = self._get_value_text(yaml_node)
                             if name_in_filesystem != name_in_agent_package:
                                 yield Error(
@@ -735,9 +739,7 @@ class Validator:
                         node=yaml_node.data.node,
                     )
                 else:
-                    relative_to: Optional[
-                        str
-                    ] = spec_node.data.expected_type.relative_to
+                    relative_to: str | None = spec_node.data.expected_type.relative_to
                     assert (
                         relative_to
                     ), f"Expected relative_to to be set in {spec_node.data.path}"

--- a/sema4ai/src/sema4ai_code/commands.py
+++ b/sema4ai/src/sema4ai_code/commands.py
@@ -138,6 +138,7 @@ SEMA4AI_OPEN_RUNBOOK_TREE_SELECTION = "sema4ai.openRunbookTreeSelection"  # Edit
 SEMA4AI_GET_RUNBOOK_PATH_FROM_AGENT_SPEC_INTERNAL = "sema4ai.getRunbookPathFromAgentSpec.internal"  # Get Runbook Path from Agent Spec (internal)
 SEMA4AI_AGENT_PACKAGE_PUBLISH_TO_SEMA4_AI_STUDIO_APP = "sema4ai.agentPackagePublishToSema4AIStudioApp"  # Publish Agent Package to Sema4.ai Studio
 SEMA4AI_AGENT_PACKAGE_IMPORT = "sema4ai.agentPackageImport"  # Import Agent Package (Zip)
+SEMA4AI_REFRESH_AGENT_SPEC_INTERNAL = "sema4ai.refreshAgentSpec.internal"  # Refresh Agent Spec (internal)
 
 ALL_SERVER_COMMANDS = [
     SEMA4AI_GET_PLUGINS_DIR,
@@ -193,6 +194,7 @@ ALL_SERVER_COMMANDS = [
     SEMA4AI_CREATE_AGENT_PACKAGE_INTERNAL,
     SEMA4AI_PACK_AGENT_PACKAGE_INTERNAL,
     SEMA4AI_GET_RUNBOOK_PATH_FROM_AGENT_SPEC_INTERNAL,
+    SEMA4AI_REFRESH_AGENT_SPEC_INTERNAL,
 ]
 
 # fmt: on

--- a/sema4ai/src/sema4ai_code/protocols.py
+++ b/sema4ai/src/sema4ai_code/protocols.py
@@ -341,7 +341,7 @@ class CreateAgentPackageParamsDict(TypedDict):
     name: str
 
 
-class GetRunbookPathFromAgentSpecDict(TypedDict):
+class AgentSpecPathDict(TypedDict):
     agent_spec_path: str
 
 

--- a/sema4ai/src/sema4ai_code/refresh_agent_spec_helper.py
+++ b/sema4ai/src/sema4ai_code/refresh_agent_spec_helper.py
@@ -1,0 +1,117 @@
+import typing
+from pathlib import Path
+from typing import TypedDict
+
+if typing.TYPE_CHECKING:
+    from sema4ai_code.agents.list_actions_from_agent import ActionPackageInFilesystem
+
+SEMA4AI = "sema4ai"
+
+
+class ActionPackage(TypedDict, total=False):
+    name: str | None
+    organization: str
+    type: str
+    version: str | None
+    whitelist: str
+    path: str
+    seen: bool
+
+
+def _update_whitelist(
+    action_package: ActionPackage,
+    whitelist_map: dict[str, ActionPackage],
+    match_key: str,
+) -> bool:
+    found_package = whitelist_map.get(match_key)
+
+    if found_package and not found_package.get("seen"):
+        action_package["whitelist"] = found_package["whitelist"]
+        found_package["seen"] = True
+        return True
+
+    return False
+
+
+def _update_agent_spec_with_actions(
+    agent_spec: dict,
+    action_packages_in_filesystem: list["ActionPackageInFilesystem"],
+    whitelist_map: dict[str, ActionPackage],
+) -> None:
+    new_action_packages: list[ActionPackage] = [
+        {
+            "name": action_package.get_name(),
+            "organization": action_package.organization,
+            "version": action_package.get_version(),
+            "path": action_package.relative_path,
+            "type": "zip" if action_package.zip_path else "folder",
+            "whitelist": "",
+        }
+        for action_package in action_packages_in_filesystem
+        if action_package.organization.replace(".", "").lower() != SEMA4AI
+    ]
+    missing = []
+
+    # First try to match by path.
+    for action_package in new_action_packages:
+        if not _update_whitelist(
+            action_package,
+            whitelist_map,
+            match_key=action_package["path"],
+        ):
+            missing.append(action_package)
+
+    # Couldn't find a path match, try to match by name.
+    for action_package in missing:
+        if action_package["name"]:
+            _update_whitelist(
+                action_package, whitelist_map, match_key=action_package["name"]
+            )
+
+    # If there was a whitelisted action and it wasn't matched, keep the old config
+    # around so that the user can fix it.
+    for whitelisted_action in whitelist_map.values():
+        if not whitelisted_action.pop("seen", False):
+            new_action_packages.append(whitelisted_action)
+
+    agent_spec["agent-package"]["agents"][0]["action-packages"] = new_action_packages
+
+
+def _create_whitelist_mapping(agent_spec: dict) -> dict[str, ActionPackage]:
+    whitelist_mapping = {}
+
+    for action_package in agent_spec["agent-package"]["agents"][0].get(
+        "action-packages", []
+    ):
+        if action_package.get("whitelist"):
+            if action_package.get("name"):
+                whitelist_mapping[action_package["name"]] = action_package
+
+            if action_package.get("path"):
+                whitelist_mapping[action_package["path"]] = action_package
+
+    return whitelist_mapping
+
+
+def update_agent_spec(agent_spec_path: Path) -> None:
+    from ruamel.yaml import YAML
+
+    from sema4ai_code.agents.list_actions_from_agent import list_actions_from_agent
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+
+    with agent_spec_path.open("r") as file:
+        agent_spec = yaml.load(file)
+
+    action_packages_in_filesystem = list(
+        list_actions_from_agent(agent_spec_path.parent).values()
+    )
+    current_whitelist_mapping = _create_whitelist_mapping(agent_spec)
+
+    _update_agent_spec_with_actions(
+        agent_spec, action_packages_in_filesystem, current_whitelist_mapping
+    )
+
+    with agent_spec_path.open("w") as file:
+        yaml.dump(agent_spec, file)

--- a/sema4ai/src/sema4ai_code/robocorp_language_server.py
+++ b/sema4ai/src/sema4ai_code/robocorp_language_server.py
@@ -38,13 +38,13 @@ from sema4ai_code.protocols import (
     ActionServerPackageUploadDict,
     ActionServerPackageUploadStatusDict,
     ActionServerVerifyLoginResultDict,
+    AgentSpecPathDict,
     CloudListWorkspaceDict,
     ConfigurationDiagnosticsDict,
     CreateActionPackageParamsDict,
     CreateAgentPackageParamsDict,
     CreateRobotParamsDict,
     DownloadToolDict,
-    GetRunbookPathFromAgentSpecDict,
     IRccRobotMetadata,
     IRccWorkspace,
     ListActionsParams,
@@ -60,6 +60,7 @@ from sema4ai_code.protocols import (
     WorkItem,
     WorkspaceInfoDict,
 )
+from sema4ai_code.refresh_agent_spec_helper import update_agent_spec
 from sema4ai_code.vendored_deps.package_deps._deps_protocols import (
     ICondaCloud,
     IPyPiCloud,
@@ -1700,7 +1701,7 @@ class RobocorpLanguageServer(PythonLanguageServer, InspectorLanguageServer):
 
     @command_dispatcher(commands.SEMA4AI_GET_RUNBOOK_PATH_FROM_AGENT_SPEC_INTERNAL)
     def _get_runbook_path_from_agent_spec(
-        self, params: GetRunbookPathFromAgentSpecDict
+        self, params: AgentSpecPathDict
     ) -> ActionResultDict:
         agent_spec_path = params["agent_spec_path"]
 
@@ -1721,6 +1722,17 @@ class RobocorpLanguageServer(PythonLanguageServer, InspectorLanguageServer):
             message=None,
             result=runbook_path,
         ).as_dict()
+
+    @command_dispatcher(commands.SEMA4AI_REFRESH_AGENT_SPEC_INTERNAL)
+    def _refresh_agent_spec(self, params: AgentSpecPathDict) -> ActionResultDict:
+        try:
+            update_agent_spec(Path(params["agent_spec_path"]))
+        except Exception as e:
+            return ActionResult(
+                success=False, message=f"Failed to refresh the agent configuration: {e}"
+            ).as_dict()
+
+        return ActionResult(success=True, message=None).as_dict()
 
     def _pack_agent_package_threaded(self, directory, ws, monitor: IMonitor):
         from sema4ai_ls_core.progress_report import progress_context

--- a/sema4ai/tests/sema4ai_code_tests/agents/test_agent_spec_analysis/test_agent_spec_analysis_v2_agent3_v2_unreferenced_action_package_.yml
+++ b/sema4ai/tests/sema4ai_code_tests/agents/test_agent_spec_analysis/test_agent_spec_analysis_v2_agent3_v2_unreferenced_action_package_.yml
@@ -18,5 +18,5 @@
     start:
       character: 10
       line: 14
-  severity: 1
+  severity: 2
   source: sema4ai

--- a/sema4ai/tests/sema4ai_code_tests/test_vscode_integration.py
+++ b/sema4ai/tests/sema4ai_code_tests/test_vscode_integration.py
@@ -9,6 +9,17 @@ from typing import Dict, List, Optional
 from unittest import mock
 
 import pytest
+from sema4ai_code_tests.fixtures import RCC_TEMPLATE_NAMES, RccPatch
+from sema4ai_code_tests.protocols import IRobocorpLanguageServerClient
+from sema4ai_ls_core.basic import wait_for_condition
+from sema4ai_ls_core.callbacks import Callback
+from sema4ai_ls_core.ep_resolve_interpreter import (
+    DefaultInterpreterInfo,
+    IInterpreterInfo,
+)
+from sema4ai_ls_core.pluginmanager import PluginManager
+from sema4ai_ls_core.unittest_tools.cases_fixture import CasesFixture
+
 from sema4ai_code.inspector.common import (
     STATE_CLOSED,
     STATE_NOT_PICKING,
@@ -21,17 +32,6 @@ from sema4ai_code.protocols import (
     LocalPackageMetadataInfoDict,
     WorkspaceInfoDict,
 )
-from sema4ai_ls_core.basic import wait_for_condition
-from sema4ai_ls_core.callbacks import Callback
-from sema4ai_ls_core.ep_resolve_interpreter import (
-    DefaultInterpreterInfo,
-    IInterpreterInfo,
-)
-from sema4ai_ls_core.pluginmanager import PluginManager
-from sema4ai_ls_core.unittest_tools.cases_fixture import CasesFixture
-
-from sema4ai_code_tests.fixtures import RCC_TEMPLATE_NAMES, RccPatch
-from sema4ai_code_tests.protocols import IRobocorpLanguageServerClient
 
 log = logging.getLogger(__name__)
 
@@ -1081,10 +1081,9 @@ def test_hover_image_integration(
 ):
     import base64
 
+    from sema4ai_code_tests.fixtures import IMAGE_IN_BASE64
     from sema4ai_ls_core import uris
     from sema4ai_ls_core.workspace import Document
-
-    from sema4ai_code_tests.fixtures import IMAGE_IN_BASE64
 
     locators_json = tmpdir.join("locators.json")
     locators_json.write_text("", "utf-8")
@@ -1355,13 +1354,14 @@ def test_profile_import(
     datadir,
     disable_rcc_diagnostics,
 ):
+    from sema4ai_ls_core import uris
+
     from sema4ai_code.commands import (
         SEMA4AI_GET_PY_PI_BASE_URLS_INTERNAL,
         SEMA4AI_PROFILE_IMPORT_INTERNAL,
         SEMA4AI_PROFILE_LIST_INTERNAL,
         SEMA4AI_PROFILE_SWITCH_INTERNAL,
     )
-    from sema4ai_ls_core import uris
 
     result = language_server_initialized.execute_command(
         SEMA4AI_GET_PY_PI_BASE_URLS_INTERNAL,
@@ -1680,11 +1680,10 @@ def test_web_inspector_integrated(
     This test should be a reference spanning all the APIs that are available
     for the inspector webview to use.
     """
-    from sema4ai_ls_core import uris
-
     from sema4ai_code_tests.robocode_language_server_client import (
         RobocorpLanguageServerClient,
     )
+    from sema4ai_ls_core import uris
 
     cases.copy_to("robots", ws_root_path)
     ls_client: RobocorpLanguageServerClient = language_server_initialized
@@ -2313,6 +2312,7 @@ def test_create_and_pack_and_import_agent_package(
     assert os.path.exists(agent_cli_location)
 
     import yaml
+
     from sema4ai_code import commands
 
     language_server = language_server_initialized
@@ -2411,6 +2411,7 @@ def test_get_runbook_from_agent_spec(
     tmpdir,
 ) -> None:
     import yaml
+
     from sema4ai_code import commands
 
     language_server = language_server_initialized
@@ -2464,3 +2465,69 @@ def test_get_runbook_from_agent_spec(
 
     assert not result["success"]
     assert result["message"] == "Runbook entry was not found in the agent spec."
+
+
+def test_refresh_agent_spec_on_action_creation(
+    language_server_initialized,
+    tmpdir,
+    agent_cli_location: str,
+) -> None:
+    assert os.path.exists(agent_cli_location)
+
+    import yaml
+
+    from sema4ai_code import commands
+
+    language_server = language_server_initialized
+    package_name = "test_agent"
+
+    target_directory = str(tmpdir.join(package_name))
+    language_server.change_workspace_folders(
+        added_folders=[target_directory], removed_folders=[]
+    )
+
+    result = language_server.execute_command(
+        commands.SEMA4AI_CREATE_AGENT_PACKAGE_INTERNAL,
+        [
+            {
+                "directory": target_directory,
+                "name": "Test Agent",
+            }
+        ],
+    )["result"]
+
+    assert result["success"]
+    assert os.path.exists(f"{target_directory}/agent-spec.yaml")
+
+    result = language_server.execute_command(
+        commands.SEMA4AI_CREATE_ACTION_PACKAGE_INTERNAL,
+        [
+            {
+                "directory": f"{target_directory}/actions/MyActions/one",
+                "name": "One",
+                "template": "basic",
+            }
+        ],
+    )["result"]
+    assert result["success"]
+
+    result = language_server.execute_command(
+        commands.SEMA4AI_REFRESH_AGENT_SPEC_INTERNAL,
+        [{"agent_spec_path": f"{target_directory}/agent-spec.yaml"}],
+    )["result"]
+    assert result["success"]
+
+    with open(f"{target_directory}/agent-spec.yaml") as stream:
+        agent_spec = yaml.safe_load(stream)
+
+    action_packages = {
+        "name": "One",
+        "organization": "MyActions",
+        "version": "0.0.1",
+        "path": "MyActions/one",
+        "type": "folder",
+        "whitelist": "",
+    }
+    assert agent_spec["agent-package"]["agents"][0]["action-packages"] == [
+        action_packages
+    ]

--- a/sema4ai/vscode-client/src/common.ts
+++ b/sema4ai/vscode-client/src/common.ts
@@ -25,6 +25,10 @@ export type PackageTargetAndNameResult = {
     name: string | null;
 };
 
+export type ActionPackageTargetInfo = PackageTargetAndNameResult & {
+    agentSpecPath: string | null;
+};
+
 export const debounce = (func, wait) => {
     let timeout: NodeJS.Timeout;
 

--- a/sema4ai/vscode-client/src/robocorpCommands.ts
+++ b/sema4ai/vscode-client/src/robocorpCommands.ts
@@ -137,3 +137,4 @@ export const SEMA4AI_OPEN_RUNBOOK_TREE_SELECTION = "sema4ai.openRunbookTreeSelec
 export const SEMA4AI_GET_RUNBOOK_PATH_FROM_AGENT_SPEC_INTERNAL = "sema4ai.getRunbookPathFromAgentSpec.internal";  // Get Runbook Path from Agent Spec (internal)
 export const SEMA4AI_AGENT_PACKAGE_PUBLISH_TO_SEMA4_AI_STUDIO_APP = "sema4ai.agentPackagePublishToSema4AIStudioApp";  // Publish Agent Package to Sema4.ai Studio
 export const SEMA4AI_AGENT_PACKAGE_IMPORT = "sema4ai.agentPackageImport";  // Import Agent Package (Zip)
+export const SEMA4AI_REFRESH_AGENT_SPEC_INTERNAL = "sema4ai.refreshAgentSpec.internal";  // Refresh Agent Spec (internal)


### PR DESCRIPTION
Add refresh agent spec internal command to update the action packages in agent-spec.yaml when adding a new action package.

This PR mostly addresses the happy paths. We will address edge cases in a follow-up PR.