### PR TITLE
Preventing pop-ups for the rcc diagnostic warnings.

### DIFF
--- a/sema4ai/vscode-client/src/extensionCreateEnv.ts
+++ b/sema4ai/vscode-client/src/extensionCreateEnv.ts
@@ -393,7 +393,7 @@ export async function basicValidations(
         if (failedCheck.status == STATUS_FATAL) {
             canProceed = false;
         }
-        
+
         let func = window.showWarningMessage;
 
         if (failedCheck.status == STATUS_WARNING) {

--- a/sema4ai/vscode-client/src/extensionCreateEnv.ts
+++ b/sema4ai/vscode-client/src/extensionCreateEnv.ts
@@ -390,17 +390,18 @@ export async function basicValidations(
     }
     let canProceed: boolean = true;
     for (const failedCheck of rccDiagnostics.failedChecks) {
-        let func;
         if (failedCheck.status == STATUS_FATAL) {
             canProceed = false;
-            func = window.showErrorMessage;
         }
+        
+        let func = window.showWarningMessage;
+
         if (failedCheck.status == STATUS_WARNING) {
             if (failedCheck.category == 1030 && failedCheck.type == "OS") {
-                // No pop-up but added to the output so that is visible in support logs
+                // These warnings have no actionable thing for the user to do.
+                // No pop-up but added to the output, so that is visible in support logs
                 OUTPUT_CHANNEL.appendLine("RCC diagostics warning/info: " + failedCheck.message);
-            } else {
-                func = window.showWarningMessage;
+                func = undefined;
             }
         }
 

--- a/sema4ai/vscode-client/src/extensionCreateEnv.ts
+++ b/sema4ai/vscode-client/src/extensionCreateEnv.ts
@@ -390,17 +390,28 @@ export async function basicValidations(
     }
     let canProceed: boolean = true;
     for (const failedCheck of rccDiagnostics.failedChecks) {
+        let func;
         if (failedCheck.status == STATUS_FATAL) {
             canProceed = false;
+            func = window.showErrorMessage;
         }
-        let func = window.showErrorMessage;
         if (failedCheck.status == STATUS_WARNING) {
-            func = window.showWarningMessage;
+            if (failedCheck.category == 1030 && failedCheck.type == "OS") {
+                // No pop-up but added to the output so that is visible in support logs
+                OUTPUT_CHANNEL.appendLine("RCC diagostics warning/info: " + failedCheck.message);
+            } else {
+                func = window.showWarningMessage;
+            }
         }
-        if (failedCheck.url) {
-            func(failedCheck.message, "Open troubleshoot URL").then(createOpenUrl(failedCheck));
-        } else {
-            func(failedCheck.message);
+
+        if (func) {
+            // Warning or error pop-up will be shown
+            // Add link to help if available
+            if (failedCheck.url) {
+                func(failedCheck.message, "Open troubleshoot URL").then(createOpenUrl(failedCheck));
+            } else {
+                func(failedCheck.message);
+            }
         }
     }
     if (!canProceed) {


### PR DESCRIPTION
Because we cannot provide any concrete step to the user, better to just log these to the output, so that they do not confuse users. These warnings are:
- CURL_CA_BUNDLE is set
- NODE_EXTRA_CA_CERTS is set
- NODE_OPTIONS is set
- NODE_PATH is set
- NODE_TLS_REJECT_UNAUTHORIZED is set
- PIP_CONFIG_FILE is set
- PLAYWRIGHT_BROWSERS_PATH is set
- PYTHONPATH is set
- REQUESTS_CA_BUNDLE is set
- SSL_CERT_DIR is set
- SSL_CERT_FILE is set
- WDM_SSL_VERIFY is set
- VIRTUAL_ENV is set