### PR TITLE
Bump agent-cli to v0.2.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Update Action Server to `2.3.0`.
-- Update Agent CLI to `0.2.0`
+- Update Agent CLI to `0.2.1`
 
 ## New in 2.8.1 (2024-11-21)
 

--- a/sema4ai/src/sema4ai_code/agent_cli.py
+++ b/sema4ai/src/sema4ai_code/agent_cli.py
@@ -24,7 +24,7 @@ if typing.TYPE_CHECKING:
 
 log = get_logger(__name__)
 
-AGENT_CLI_VERSION = "v0.2.0"
+AGENT_CLI_VERSION = "v0.2.1"
 
 
 def download_agent_cli(


### PR DESCRIPTION
- Found and fixes a backward comp. break

Stable release checklist:  

* [ ] Updated the version using `python -m dev set-version {version}` 
* [ ] Updated `/docs/changelog.md` with the changes for the release

Pre-release checklist:

* [x] Updated the **Unreleased** section of `/docs/changelog.md` with the new changes.