### PR TITLE
Fix issue where OAuth2 flow wouldn't complete because of an action se…

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 - Update Action server to `2.10.0`
 - Add better linting when an action is modified inside an agent.
 - Add error message when an action from an agent inside Sema4ai folder is modified.
+- Add `kill-lock-holder` flag to action server to kill the lock holder when starting action server for doing OAuth2 flows.
 
 ## New in 2.12.0 (2025-05-07)
 

--- a/sema4ai/src/sema4ai_code/_language_server_oauth2.py
+++ b/sema4ai/src/sema4ai_code/_language_server_oauth2.py
@@ -426,7 +426,7 @@ class _OAuth2:
                 if self._last_key == key:
                     # See if we can make a request and if it's live.
                     try:
-                        self._action_server_as_service.get_config()
+                        self._action_server_as_service.get_config(timeout=2)
                     except Exception:
                         self._last_key = None
                         self._action_server_as_service.stop()

--- a/sema4ai/src/sema4ai_code/action_server.py
+++ b/sema4ai/src/sema4ai_code/action_server.py
@@ -196,6 +196,8 @@ class ActionServerAsService:
         if self._ssl_certfile:
             args.append(f"--ssl-cerfile={self._ssl_certfile}")
 
+        args.append("--kill-lock-holder")
+
         self._process = Process(args, cwd=self._cwd)
         self._process.on_stderr.register(self._on_stderr)
         self._process.on_stdout.register(self._on_stdout)


### PR DESCRIPTION
…rver was still running holding the lock.

Stable release checklist:  

* [ ] Updated the version using `python -m dev set-version {version}` 
* [ ] Updated `/docs/changelog.md` with the changes for the release

Pre-release checklist:

* [ ] Updated the **Unreleased** section of `/docs/changelog.md` with the new changes.