### PR TITLE
Fix rcc path for mac arm64

### DIFF
--- a/.github/workflows/build_environments.yaml
+++ b/.github/workflows/build_environments.yaml
@@ -29,7 +29,7 @@ jobs:
             rcc_folder: macos64
           - name: macos-arm
             os: macos-15
-            rcc_folder: macos64-arm
+            rcc_folder: macos-arm64
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Stable release checklist:  

* [ ] Updated the version using `python -m dev set-version {version}` 
* [ ] Updated `/docs/changelog.md` with the changes for the release

Pre-release checklist:

* [ ] Updated the **Unreleased** section of `/docs/changelog.md` with the new changes.