### PR TITLE
DEV-1936: VSCode Ext doesn't handle the Action Packages coming from Organizations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 - Disable notifications for computing datasource status in background.
+- Update Agent CLI to `v1.3.4`
+- Enabled new organizations to be part of the Agent spec & the Actions folder in the Agent Package
 
 ## New in 2.13.0 (2025-06-10)
 

--- a/sema4ai/src/sema4ai_code/agent_cli.py
+++ b/sema4ai/src/sema4ai_code/agent_cli.py
@@ -24,7 +24,7 @@ if typing.TYPE_CHECKING:
 
 log = get_logger(__name__)
 
-AGENT_CLI_VERSION = "v1.1.5"
+AGENT_CLI_VERSION = "v1.3.4"
 
 
 def download_agent_cli(

--- a/sema4ai/src/sema4ai_code/refresh_agent_spec_helper.py
+++ b/sema4ai/src/sema4ai_code/refresh_agent_spec_helper.py
@@ -5,9 +5,6 @@ from typing import TypedDict
 if typing.TYPE_CHECKING:
     from sema4ai_code.agents.list_actions_from_agent import ActionPackageInFilesystem
 
-SEMA4AI = "sema4ai"
-MYACTIONS = "myactions"
-
 
 class ActionPackage(TypedDict, total=False):
     name: str | None
@@ -49,9 +46,7 @@ def _update_agent_spec_with_actions(
             "whitelist": "",
         }
         for action_package in action_packages_in_filesystem
-        if action_package.organization.replace(".", "").lower() in [SEMA4AI, MYACTIONS]
     ]
-
     missing = []
 
     # First try to match by path.

--- a/sema4ai/vscode-client/src/robo/importActions.ts
+++ b/sema4ai/vscode-client/src/robo/importActions.ts
@@ -49,11 +49,10 @@ export const importActionPackage = async (agentPath?: string) => {
         }
 
         const packages = result["result"];
-
         if (!packages) {
             throw new Error("No packages found in metadata");
         }
-        const options: QuickPickItemWithAction[] = [];
+
         const entries = Object.entries(packages);
 
         // Sort entries by the name and version
@@ -89,6 +88,7 @@ export const importActionPackage = async (agentPath?: string) => {
             return nameA.localeCompare(nameB);
         });
 
+        const options: QuickPickItemWithAction[] = [];
         for (const [key, value] of entries) {
             options.push({
                 "label": key,


### PR DESCRIPTION
## Description

Updating the agent-cli version. Alleviate issues for the agent spec file when new organization action package is added or imported.

[DEV-1936: VSCode Ext doesn't handle the Action Packages coming from Organizations](https://linear.app/sema4ai/issue/DEV-1936/vscode-ext-doesnt-handle-the-action-packages-coming-from-organizations)

## How was this tested?

Manual

## Screenshots (if possible)

![image](https://github.com/user-attachments/assets/63b31940-7673-46b6-93e2-49993831b588)

## Pre-Release checklist:

* [x] Updated the **Unreleased** section of `/docs/changelog.md` with the new changes.

## Stable Release checklist:

* [ ] Updated the version using `python -m dev set-version {version}`
* [ ] Updated `/docs/changelog.md` with the changes for the release
