### PR TITLE
Release Sema4.ai VSCode extension 2.12.5

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+
+## New in 2.14.5 (2025-09-12)
+
 - Update `Agent CLI` to `2.2.0`
 - Update `Action Server` to `2.14.0`
 - Add validation for document-intelligence in agent-spec

--- a/sema4ai/package.json
+++ b/sema4ai/package.json
@@ -14,7 +14,7 @@
         "url": "https://github.com/Sema4AI/vscode-extension/.git"
     },
     "license": "SEE LICENSE",
-    "version": "2.14.2",
+    "version": "2.12.5",
     "icon": "images/icon.png",
     "engines": {
         "vscode": "^1.65.0"

--- a/sema4ai/pyproject.toml
+++ b/sema4ai/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sema4ai-vscode-extension"
-version = "2.14.2"
+version = "2.12.5"
 description = "Sema4.ai: Visual Studio Code Extension for AI Actions and Robot Tasks development"
 authors = ["Fabio Zadrozny <fabio@robocorp.com>"]
 readme = "README.md"

--- a/sema4ai/src/sema4ai_code/__init__.py
+++ b/sema4ai/src/sema4ai_code/__init__.py
@@ -2,7 +2,7 @@ import os.path
 import sys
 from typing import List
 
-__version__ = "2.14.2"
+__version__ = "2.12.5"
 version_info: list[int] = [int(x) for x in __version__.split(".")]
 
 __file__ = os.path.abspath(__file__)


### PR DESCRIPTION
## Description

Pushing preview 2.14.4 to stable 2.14.5

## How was this tested?

Following the release.md guide


## Pre-Release checklist:

* [x] Updated the **Unreleased** section of `/docs/changelog.md` with the new changes.

## Stable Release checklist:

* [x] Updated the version using `python -m dev set-version {version}`
* [x] Updated `/docs/changelog.md` with the changes for the release
