### PR TITLE
Updates to integration with Data extension

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Improve the error messages when data server is not running
+
 ## New in 2.15.0 (2025-09-12)
 
 - Update `Agent CLI` to `2.2.0`

--- a/sema4ai/vscode-client/src/actionServer.ts
+++ b/sema4ai/vscode-client/src/actionServer.ts
@@ -9,7 +9,7 @@ import { listAndAskRobotSelection } from "./activities";
 import { ActionResult, ActionServerVerifyLoginOutput, ActionServerListOrganizationsOutput } from "./protocols";
 import { Tool, getToolVersion, downloadTool } from "./tools";
 import { langServer } from "./extension";
-import { fetchDataServerStatus } from "./robo/dataSourceHandling";
+import { fetchDataServerStatus } from "./dataExtension";
 import { convertDataServerInfoToEnvVar } from "./robo/actionPackage";
 
 const ACTION_SERVER_DEFAULT_PORT = 8082;

--- a/sema4ai/vscode-client/src/dataExtension.ts
+++ b/sema4ai/vscode-client/src/dataExtension.ts
@@ -1,10 +1,7 @@
-import { commands, extensions, window } from "vscode";
+import { commands, extensions, window, ProgressLocation } from "vscode";
 import { logError, OUTPUT_CHANNEL } from "./channel";
-import { DataServerConfig } from "./robo/actionPackage";
 
 const DATA_EXTENSION_ID = "sema4ai.sema4ai-data-access";
-export const DATA_SERVER_START_COMMAND_ID = "sema4ai-data.dataserver.start";
-export const DATA_SERVER_STOP_COMMAND_ID = "sema4ai-data.dataserver.stop";
 export const DATA_SERVER_STATUS_COMMAND_ID = "sema4ai-data.dataserver.status";
 export const DATABASE_ADD_COMMAND_ID = "sema4ai-data.database.add";
 
@@ -87,68 +84,20 @@ export async function verifyDataExtensionIsInstalled(
     return false;
 }
 
-function failWithErrorMessage(dataServerInfo: DataServerConfig, errorMessage: string) {
-    OUTPUT_CHANNEL.appendLine(
-        `${errorMessage} (obtained from the ${DATA_SERVER_START_COMMAND_ID} command). Full data server info: ` +
-            JSON.stringify(dataServerInfo, null, 4)
+export async function fetchDataServerStatus(): Promise<any | null> {
+    return window.withProgress(
+        { location: ProgressLocation.Notification, title: "Getting data server status...", cancellable: false },
+        async () => {
+            const status = await commands.executeCommand(DATA_SERVER_STATUS_COMMAND_ID);
+            if (!status["success"]) {
+                window.showErrorMessage("Unable to get the data server status. Please start the data server and try again.");
+                return null;
+            }
+            if (!status["data"]["is_running"]) {
+                window.showErrorMessage("The data server is not running. Please start the data server and try again.");
+                return null;
+            }
+            return status;
+        }
     );
-    window.showErrorMessage(errorMessage);
-}
-
-export async function startDataServerAndGetInfo(): Promise<DataServerConfig | undefined> {
-    const dataServerInfo = (await commands.executeCommand(DATA_SERVER_START_COMMAND_ID, {
-        "showUIMessages": false,
-    })) as DataServerConfig | undefined;
-    if (dataServerInfo) {
-        if (!dataServerInfo.is_running) {
-            failWithErrorMessage(
-                dataServerInfo,
-                "After starting the data server, is_running still returning false in provided data server config."
-            );
-            return undefined;
-        }
-
-        // Let's validate that the data server info has the correct structure (check each field one by one and
-        // show error if it's not correct)
-        if (!dataServerInfo.api) {
-            failWithErrorMessage(dataServerInfo, "The data server info is missing the 'api' field");
-            return undefined;
-        }
-
-        if (!dataServerInfo.api.http) {
-            failWithErrorMessage(dataServerInfo, "The data server info is missing the 'api.http' field");
-            return undefined;
-        }
-
-        if (!dataServerInfo.api.http.host) {
-            failWithErrorMessage(dataServerInfo, "The data server info is missing the 'api.http.host' field");
-            return undefined;
-        }
-
-        if (!dataServerInfo.api.http.port) {
-            failWithErrorMessage(dataServerInfo, "The data server info is missing the 'api.http.port' field");
-            return undefined;
-        }
-
-        if (!dataServerInfo.api.mysql) {
-            failWithErrorMessage(dataServerInfo, "The data server info is missing the 'api.mysql' field");
-            return undefined;
-        }
-
-        if (!dataServerInfo.api.mysql.host) {
-            failWithErrorMessage(dataServerInfo, "The data server info is missing the 'api.mysql.host' field");
-            return undefined;
-        }
-
-        if (!dataServerInfo.api.mysql.port) {
-            failWithErrorMessage(dataServerInfo, "The data server info is missing the 'api.mysql.port' field");
-            return undefined;
-        }
-
-        if (!dataServerInfo.auth) {
-            failWithErrorMessage(dataServerInfo, "The data server info is missing the 'auth' field");
-            return undefined;
-        }
-    }
-    return dataServerInfo;
 }

--- a/sema4ai/vscode-client/src/rcc.ts
+++ b/sema4ai/vscode-client/src/rcc.ts
@@ -148,7 +148,7 @@ async function downloadRcc(
             throw new Error("Currently only Linux amd64 is supported.");
         }
     }
-    const RCC_VERSION = "v18.5.0";
+    const RCC_VERSION = "v20.1.1";
     const prefix = "https://cdn.sema4.ai/rcc/releases/" + RCC_VERSION;
     const url: string = prefix + relativePath;
     return await downloadWithProgress(url, progress, token, location);

--- a/sema4ai/vscode-client/src/robo/actionPackage.ts
+++ b/sema4ai/vscode-client/src/robo/actionPackage.ts
@@ -64,7 +64,7 @@ import {
     updateActionInputsMetadata,
 } from "./actionInputs";
 import { langServer } from "../extension";
-import { startDataServerAndGetInfo, verifyDataExtensionIsInstalled } from "../dataExtension";
+import { fetchDataServerStatus, verifyDataExtensionIsInstalled } from "../dataExtension";
 
 export interface QuickPickItemAction extends QuickPickItem {
     actionPackageUri: vscode.Uri;
@@ -663,7 +663,12 @@ advised to regenerate it as it may not work with future versions of the extensio
                         progress.report({
                             message: "Waiting for data server info... ",
                         });
-                        const dataServerInfo = await startDataServerAndGetInfo();
+
+                        const dataServerStatus = await fetchDataServerStatus();
+                        if (!dataServerStatus) {
+                            return false;
+                        }
+                        const dataServerInfo = dataServerStatus["data"];
                         if (!dataServerInfo) {
                             window.showErrorMessage(
                                 "Unable to run (error getting local data server connection info):\n" +


### PR DESCRIPTION
## Description

- Just use `sema4ai-data.dataserver.status` command to get data server status and stop using `sema4ai-data.dataserver.start` command since its deprecated.

## Context

- Since Data extension v1.4.4, the data server management has been removed from extension and it relies solely on studio to download/install/start/stop data server.

## Linear

[CON-1369](https://linear.app/sema4ai/issue/CON-1369/data-extension-get-data-server-via-studiol)

## How was this tested?

- When Data extension is not installed.
  - Verified that SDK extension shows message to install the Data extension, when user tries to add/delete data source or run named query.
- When Data extension stable release v1.4.0 is installed.
  - Verified that SDK extension shows message to start data server if its not running, when user tries to add/delete data source or run named query.
- When Data extension stable release v1.4.4 is installed.
  - Verified that SDK extension shows message to start data server if its not running, when user tries to add/delete data source or run named query.

## Screenshots (if possible)

<img width="960" height="475" alt="data extension not installed" src="https://github.com/user-attachments/assets/812175f1-2412-4a4f-8224-fac5f6495b43" />
<img width="960" height="475" alt="data extension v1 4 0 is installed" src="https://github.com/user-attachments/assets/1bd3bf4f-0284-43ae-8c11-1428f5dbca83" />
<img width="960" height="474" alt="data extension v1 4 4 is installed" src="https://github.com/user-attachments/assets/0b6e86e1-4f72-4b77-bc2b-6dae94e656d2" />

## Pre-Release checklist:

* [x] Updated the **Unreleased** section of `/docs/changelog.md` with the new changes.

## Stable Release checklist:

* [ ] Updated the version using `python -m dev set-version {version}`
* [ ] Updated `/docs/changelog.md` with the changes for the release
